### PR TITLE
Add vscode-jsonrpc to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     },
     "extensionDependencies": [],
     "dependencies": {
+        "vscode-jsonrpc": "^4.0.0",
         "extract-zip": "^1.6.7",
         "follow-redirects": "^1.7.0",
         "rimraf": "^2.6.3",


### PR DESCRIPTION
This fixes an issue on startup where coc complains that it cannot find module "vscode-jsonrpc".