### PR TITLE
add support for custom omnisharp installations/executables using a new property 'path'

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,11 +71,10 @@
             "type": "object",
             "title": "OmniSharp Configuration",
             "properties": {
-                "omnisharp.useDotnet": {
-                    "scope": "resource",
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Use 'dotnet' to start OmniSharp"
+                "omnisharp.path": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Use a custom executable instead of the included bundle"
                 }
             }
         },

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -43,9 +43,12 @@ export async function activate(context: ExtensionContext) {
         }
     }
 
-    const omnisharpProvider = new LanguageServerProvider(context, "OmniSharp", omnisharpPacks, omnisharpRepo)
-    const omnisharpExe = await omnisharpProvider.getLanguageServer()
     const config = workspace.getConfiguration('omnisharp')
+    const omnisharpCustomPath = config.get<string>('path')
+    const useCustomPath = omnisharpCustomPath.length > 0;
+
+    const omnisharpProvider = new LanguageServerProvider(context, "OmniSharp", omnisharpPacks, omnisharpRepo)
+    const omnisharpExe = useCustomPath ? omnisharpCustomPath : await omnisharpProvider.getLanguageServer();
 
     let serverOptions =
     {
@@ -70,6 +73,9 @@ export async function activate(context: ExtensionContext) {
             await sleep(1000)
         }
         await omnisharpProvider.downloadLanguageServer()
+        if (useCustomPath) {
+            workspace.showMessage(`coc-omnisharp: Using custom executable (${omnisharpCustomPath}) so the downloaded bundle will have no effect`, 'warning')
+        }
         client_dispose = client.start()
         context.subscriptions.push(client_dispose)
     })


### PR DESCRIPTION
This PR introduces a new option `"omnisharp.path"` which lets the user specify the executable for omnisharp.
Motivation: On NixOS there are problems with the bundled omnisharp versions.
The solution is to use Omnisharp provided by nixpkgs as seen here: https://github.com/NixOS/nixpkgs/pull/57205#issuecomment-487260542

I have also removed the property `"useDotnet"` as it seems that it isn't used anymore?