### PR TITLE
added 'prepare' script to allow compilation/build on 'npm install'

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
         ]
     },
     "scripts": {
+        "prepare": "npx npm-run-all compile",
         "compile": "tsc -p ./",
         "watch": "tsc -watch -p ./"
     },


### PR DESCRIPTION
This adds the possibility to install the extension via a vim-plugin manager like vim-plug (as described here: https://github.com/neoclide/coc.nvim/wiki/Using-coc-extensions#use-vims-plugin-manager-for-coc-extension):
`Plug 'coc-extensions/coc-omnisharp', {'do': 'npm ci'}`
