### PR TITLE
Add support to use specific omnisharp version

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,29 @@ Alternatively, you can have `coc.nvim` automatically install the extension if it
 let g:coc_global_extensions=[ 'coc-omnisharp', ... ]
 ```
 
+## Configuration
+
+
+You can call `:CocConfig` to edit configuration. Available options are:
+
+|          Key           |             Description            |           Type         |   Default   |
+| ---------------------- | ---------------------------------- | ---------------------- | ----------- |
+| omnisharp.version      | Download a specific version        | string                 | latest      |
+| omnisharp.path         | For use with existing installation | string                 |             |
+| omnisharp.trace.server | Specify trace level                | information \| verbose | information |
+| omnisharp.debug.server | Wait for debugger                  | boolean                | false       |
+
+#### Example configuration:
+
+```json
+{
+    "omnisharp.version": "v.1.37.3",
+    "omnisharp.trace.server": "information",
+    "omnisharp.debug.server": true
+}
+```
+
+
 ## Recommended plugins
 
 [vim-polyglot](https://github.com/sheerun/vim-polyglot) for syntax highlighting 🎨

--- a/package.json
+++ b/package.json
@@ -71,6 +71,11 @@
             "type": "object",
             "title": "OmniSharp Configuration",
             "properties": {
+                "omnisharp.version": {
+                    "type": "string",
+                    "default": "latest",
+                    "description": "Download a specific OmniSharp-Roslyn version"
+                },
                 "omnisharp.path": {
                     "type": "string",
                     "default": "",

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -1,15 +1,25 @@
 /* --------------------------------------------------------------------------------------------
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
- * ------------------------------------------------------------------------------------------ */
+ * ------------------------------------------------------------------------------------------
+ */
 'use strict';
 
-import fs = require('fs')
-import path = require('path')
-import {workspace, ExtensionContext, commands, RevealOutputChannelOn} from 'coc.nvim';
-import {LanguageClient, LanguageClientOptions} from 'coc.nvim';
-
-import {LanguageServerRepository, LanguageServerProvider, ILanguageServerPackages, sleep} from 'coc-utils'
+import fs from 'fs';
+import path from 'path';
+import {
+    ExtensionContext,
+    commands,
+    workspace,
+    LanguageClient,
+    LanguageClientOptions
+} from 'coc.nvim';
+import {
+    LanguageServerRepository,
+    LanguageServerProvider,
+    ILanguageServerPackages,
+    sleep
+} from 'coc-utils'
 
 const logger = workspace.createOutputChannel("coc-omnisharp")
 const omnisharpLogger = workspace.createOutputChannel("omnisharp")
@@ -57,23 +67,23 @@ export async function activate(context: ExtensionContext) {
 
     // find the solution file
     let sln = fs.readdirSync(workspace.rootPath)
-      .map(x => path.join(workspace.rootPath, x))
-      .find(x => x.endsWith(".sln") && fs.statSync(x).isFile())
+        .map(x => path.join(workspace.rootPath, x))
+        .find(x => x.endsWith(".sln") && fs.statSync(x).isFile())
 
     logger.appendLine(`Solution file is: ${sln}`)
 
     let args = ["-lsp"]
     if (sln !== undefined) {
-      args.push("-s")
-      args.push(sln)
+        args.push("-s")
+        args.push(sln)
     }
     if (loglevel === "verbose") {
-      args.push("-v")
-      logger.appendLine("omnisharp verbose logging activated")
+        args.push("-v")
+        logger.appendLine("omnisharp verbose logging activated")
     }
     if (debug) {
-      args.push("--debug")
-      logger.appendLine("omnisharp debug mode activated")
+        args.push("--debug")
+        logger.appendLine("omnisharp debug mode activated")
     }
 
     let serverOptions = {

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -23,10 +23,11 @@ import {
 
 const logger = workspace.createOutputChannel("coc-omnisharp")
 const omnisharpLogger = workspace.createOutputChannel("omnisharp")
+const omnisharpVersion = workspace.getConfiguration('omnisharp').get<string>('version').toLowerCase();
 const omnisharpRepo: LanguageServerRepository = {
     kind: "github",
     repo: "omnisharp/omnisharp-roslyn",
-    channel: "latest"
+    channel: omnisharpVersion === "latest" ? omnisharpVersion : `tags/${omnisharpVersion}`
 }
 
 const omnisharpPacks: ILanguageServerPackages = {


### PR DESCRIPTION
### About

This PR allows to configure which omnisharp version to use. Defaults to latest.

### Considerations

 - Does not notify if version is incorrect
 - I couldn't manage for it to upgrade/downgrade without manual deletion of existing package.